### PR TITLE
Feature-Store Auth0 session on localStorage

### DIFF
--- a/FRONT/src/auth0-provider.js
+++ b/FRONT/src/auth0-provider.js
@@ -10,6 +10,7 @@ export const Auth0ProviderModule = ({ children }) => {
       authorizationParams={{
         redirect_uri: "http://localhost:3000/home",
       }}
+      cacheLocation="localstorage"
     >
       {children}
     </Auth0Provider>


### PR DESCRIPTION
Hola Chicos, se agregó una linea en auth0ProviderModule que genera que se guarde el caché de la session en localStorage. Por esto la sesión se mantiene activa aunque se recargue la página.