### PR TITLE
Fix nodemailer tls certificates

### DIFF
--- a/API/src/mailer/mailer.js
+++ b/API/src/mailer/mailer.js
@@ -11,6 +11,9 @@ const transporter = nodemailer.createTransport({
     user: NODEMAILER_USER,
     pass: NODEMAILER_PASS,
   },
+  tls: {
+    rejectUnauthorized: false,
+  },
 });
 
 module.exports = transporter;


### PR DESCRIPTION
Agregada una linea en el transporter de nodemailer para evitar el error con los certificados TLS